### PR TITLE
chore: refine reusable backend template baseline

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   db:
     image: mysql:8.0


### PR DESCRIPTION
## Summary
- keep repo as generic Bun + Elysia + Drizzle + MySQL template
- remove obsolete ersion field from docker-compose.yml to avoid Compose warning
- preserve current template structure and flexibility for any future use case