### PR TITLE
feat(users): implement login endpoint with session token

### DIFF
--- a/drizzle/0001_familiar_imperial_guard.sql
+++ b/drizzle/0001_familiar_imperial_guard.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `sessions` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`token` varchar(255) NOT NULL,
+	`user_id` int NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `sessions_id` PRIMARY KEY(`id`),
+	CONSTRAINT `sessions_token_unique` UNIQUE(`token`)
+);
+--> statement-breakpoint
+ALTER TABLE `sessions` ADD CONSTRAINT `sessions_user_id_users_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,147 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "ece6d0f6-0b4b-4e06-981a-4cb7d5710e7f",
+  "prevId": "6d6957ba-b84d-4e21-8ae6-360ba8dc1d45",
+  "tables": {
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sessions_id": {
+          "name": "sessions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777198314523,
       "tag": "0000_steep_scarlet_witch",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1777209065886,
+      "tag": "0001_familiar_imperial_guard",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,10 +2,16 @@ import { Elysia, t } from "elysia";
 import { config } from "./lib/config";
 import { failure, success } from "./lib/response";
 import { createUsersRoutes } from "./routes/users-routes";
-import { registerUser, type RegisterUserFn } from "./services/users-service";
+import {
+  loginUser,
+  registerUser,
+  type LoginUserFn,
+  type RegisterUserFn,
+} from "./services/users-service";
 
 type CreateAppDeps = {
   registerUser?: RegisterUserFn;
+  loginUser?: LoginUserFn;
 };
 
 export const createApp = (deps: CreateAppDeps = {}): Elysia =>
@@ -26,4 +32,9 @@ export const createApp = (deps: CreateAppDeps = {}): Elysia =>
       detail: { hide: true },
       response: t.Any(),
     })
-    .use(createUsersRoutes(deps.registerUser ?? registerUser));
+    .use(
+      createUsersRoutes({
+        registerUser: deps.registerUser ?? registerUser,
+        loginUser: deps.loginUser ?? loginUser,
+      }),
+    );

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -11,3 +11,16 @@ export const users = mysqlTable(
   },
   (table) => [uniqueIndex("users_email_unique").on(table.email)],
 );
+
+export const sessions = mysqlTable(
+  "sessions",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    token: varchar("token", { length: 255 }).notNull(),
+    userId: int("user_id")
+      .notNull()
+      .references(() => users.id),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [uniqueIndex("sessions_token_unique").on(table.token)],
+);

--- a/src/routes/users-routes.ts
+++ b/src/routes/users-routes.ts
@@ -1,6 +1,9 @@
 import { Elysia, t } from "elysia";
 import {
   EmailAlreadyRegisteredError,
+  InvalidLoginError,
+  loginUser,
+  type LoginUserFn,
   registerUser,
   type RegisterUserFn,
 } from "../services/users-service";
@@ -11,40 +14,84 @@ const registerUserBodySchema = t.Object({
   password: t.String({ minLength: 1 }),
 });
 
+const loginUserBodySchema = t.Object({
+  name: t.String({ minLength: 1 }),
+  email: t.String({ minLength: 1 }),
+  password: t.String({ minLength: 1 }),
+});
+
 export const createUsersRoutes = (
-  registerUserHandler: RegisterUserFn = registerUser,
+  deps: {
+    registerUser?: RegisterUserFn;
+    loginUser?: LoginUserFn;
+  } = {},
 ): Elysia =>
-  new Elysia().post(
-    "/users",
-    async ({ body, set }) => {
-      const name = body.name.trim();
-      const email = body.email.trim();
-      const password = body.password;
+  new Elysia()
+    .post(
+      "/users",
+      async ({ body, set }) => {
+        const name = body.name.trim();
+        const email = body.email.trim();
+        const password = body.password;
 
-      if (!name || !email || !password.trim()) {
-        set.status = 400;
-        return { error: "Invalid request payload" };
-      }
-
-      try {
-        await registerUserHandler({
-          name,
-          email,
-          password,
-        });
-
-        set.status = 201;
-        return { data: "OK" };
-      } catch (error) {
-        if (error instanceof EmailAlreadyRegisteredError) {
-          set.status = 409;
-          return { error: error.message };
+        if (!name || !email || !password.trim()) {
+          set.status = 400;
+          return { error: "Invalid request payload" };
         }
 
-        throw error;
-      }
-    },
-    {
-      body: registerUserBodySchema,
-    },
-  );
+        try {
+          await (deps.registerUser ?? registerUser)({
+            name,
+            email,
+            password,
+          });
+
+          set.status = 201;
+          return { data: "OK" };
+        } catch (error) {
+          if (error instanceof EmailAlreadyRegisteredError) {
+            set.status = 409;
+            return { error: error.message };
+          }
+
+          throw error;
+        }
+      },
+      {
+        body: registerUserBodySchema,
+      },
+    )
+    .post(
+      "/users/login",
+      async ({ body, set }) => {
+        const name = body.name.trim();
+        const email = body.email.trim();
+        const password = body.password.trim();
+
+        if (!name || !email || !password) {
+          set.status = 400;
+          return { error: "Invalid request payload" };
+        }
+
+        try {
+          const token = await (deps.loginUser ?? loginUser)({
+            name,
+            email,
+            password,
+          });
+
+          set.status = 200;
+          return { data: token };
+        } catch (error) {
+          if (error instanceof InvalidLoginError) {
+            set.status = 401;
+            return { error: error.message };
+          }
+
+          throw error;
+        }
+      },
+      {
+        body: loginUserBodySchema,
+      },
+    );

--- a/src/services/users-service.ts
+++ b/src/services/users-service.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import { db } from "../db/client";
-import { users } from "../db/schema";
+import { sessions, users } from "../db/schema";
 
 export type RegisterUserInput = {
   name: string;
@@ -10,10 +10,25 @@ export type RegisterUserInput = {
 
 export type RegisterUserFn = (input: RegisterUserInput) => Promise<void>;
 
+export type LoginUserInput = {
+  name: string;
+  email: string;
+  password: string;
+};
+
+export type LoginUserFn = (input: LoginUserInput) => Promise<string>;
+
 export class EmailAlreadyRegisteredError extends Error {
   constructor() {
     super("Email sudah terdaftar");
     this.name = "EmailAlreadyRegisteredError";
+  }
+}
+
+export class InvalidLoginError extends Error {
+  constructor() {
+    super("Email atau password Salah");
+    this.name = "InvalidLoginError";
   }
 }
 
@@ -57,4 +72,34 @@ export const registerUser: RegisterUserFn = async (input) => {
 
     throw error;
   }
+};
+
+export const loginUser: LoginUserFn = async (input) => {
+  const email = normalizeEmail(input.email);
+
+  const existingUser = await db
+    .select({ id: users.id, password: users.password })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+
+  if (existingUser.length === 0) {
+    throw new InvalidLoginError();
+  }
+
+  const user = existingUser[0];
+  const isPasswordValid = await Bun.password.verify(input.password, user.password);
+
+  if (!isPasswordValid) {
+    throw new InvalidLoginError();
+  }
+
+  const token = crypto.randomUUID();
+
+  await db.insert(sessions).values({
+    token,
+    userId: user.id,
+  });
+
+  return token;
 };

--- a/tests/users.test.ts
+++ b/tests/users.test.ts
@@ -2,12 +2,22 @@ import { describe, expect, it, mock } from "bun:test";
 import { createApp } from "../src/app";
 import {
   EmailAlreadyRegisteredError,
+  InvalidLoginError,
+  type LoginUserFn,
+  type LoginUserInput,
   type RegisterUserFn,
   type RegisterUserInput,
 } from "../src/services/users-service";
 
 const requestToRegister = (payload: unknown): Request =>
   new Request("http://localhost/api/users", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+const requestToLogin = (payload: unknown): Request =>
+  new Request("http://localhost/api/users/login", {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(payload),
@@ -62,6 +72,66 @@ describe("users registration", () => {
     const app = createApp({ registerUser: registerUserMock });
     const response = await app.handle(
       requestToRegister({
+        name: "",
+        email: "zaedan@gmail.com",
+        password: "rahasia",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("users login", () => {
+  it("returns token for valid credentials", async () => {
+    let capturedInput: LoginUserInput | null = null;
+
+    const loginUserMock: LoginUserFn = mock(async (input) => {
+      capturedInput = input;
+      return "generated-token";
+    });
+
+    const app = createApp({ loginUser: loginUserMock });
+    const response = await app.handle(
+      requestToLogin({
+        name: "  zaedan  ",
+        email: "  ZAEDAN@GMAIL.COM  ",
+        password: "rahasia",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ data: "generated-token" });
+    expect(capturedInput).toEqual({
+      name: "zaedan",
+      email: "ZAEDAN@GMAIL.COM",
+      password: "rahasia",
+    });
+  });
+
+  it("returns unauthorized for invalid email or password", async () => {
+    const loginUserMock: LoginUserFn = mock(async () => {
+      throw new InvalidLoginError();
+    });
+
+    const app = createApp({ loginUser: loginUserMock });
+    const response = await app.handle(
+      requestToLogin({
+        name: "zaedan",
+        email: "zaedan@gmail.com",
+        password: "salah",
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Email atau password Salah" });
+  });
+
+  it("rejects invalid login payload", async () => {
+    const loginUserMock: LoginUserFn = mock(async () => "generated-token");
+    const app = createApp({ loginUser: loginUserMock });
+    const response = await app.handle(
+      requestToLogin({
         name: "",
         email: "zaedan@gmail.com",
         password: "rahasia",


### PR DESCRIPTION
## Summary
Implement issue #6: login feature with session token storage.

## Changes
- add sessions table in Drizzle schema with unique token and FK to users
- implement login service: validate credential, generate UUID token, save to sessions
- add POST /api/users/login route with expected success/error response
- wire login dependency in app
- add login test coverage
- add migration files for sessions table

## Verification
- bun run db:generate
- bun run db:migrate
- bun test (all pass)

Closes #6