### PR TITLE
[codex] Add current user endpoint with bearer session auth

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,8 @@ import { config } from "./lib/config";
 import { failure, success } from "./lib/response";
 import { createUsersRoutes } from "./routes/users-routes";
 import {
+  getCurrentUserByToken,
+  type GetCurrentUserFn,
   loginUser,
   registerUser,
   type LoginUserFn,
@@ -12,6 +14,7 @@ import {
 type CreateAppDeps = {
   registerUser?: RegisterUserFn;
   loginUser?: LoginUserFn;
+  getCurrentUserByToken?: GetCurrentUserFn;
 };
 
 export const createApp = (deps: CreateAppDeps = {}): Elysia =>
@@ -36,5 +39,6 @@ export const createApp = (deps: CreateAppDeps = {}): Elysia =>
       createUsersRoutes({
         registerUser: deps.registerUser ?? registerUser,
         loginUser: deps.loginUser ?? loginUser,
+        getCurrentUserByToken: deps.getCurrentUserByToken ?? getCurrentUserByToken,
       }),
     );

--- a/src/routes/users-routes.ts
+++ b/src/routes/users-routes.ts
@@ -1,11 +1,14 @@
 import { Elysia, t } from "elysia";
 import {
   EmailAlreadyRegisteredError,
+  getCurrentUserByToken,
+  type GetCurrentUserFn,
   InvalidLoginError,
   loginUser,
   type LoginUserFn,
   registerUser,
   type RegisterUserFn,
+  UnauthorizedError,
 } from "../services/users-service";
 
 const registerUserBodySchema = t.Object({
@@ -20,78 +23,124 @@ const loginUserBodySchema = t.Object({
   password: t.String({ minLength: 1 }),
 });
 
+const parseBearerToken = (authorization?: string): string | null => {
+  if (!authorization) return null;
+
+  const [scheme, ...rest] = authorization.trim().split(/\s+/);
+  if (scheme?.toLowerCase() !== "bearer") return null;
+
+  const token = rest.join(" ").trim();
+  return token ? token : null;
+};
+
 export const createUsersRoutes = (
   deps: {
     registerUser?: RegisterUserFn;
     loginUser?: LoginUserFn;
+    getCurrentUserByToken?: GetCurrentUserFn;
   } = {},
-): Elysia =>
-  new Elysia()
-    .post(
-      "/users",
-      async ({ body, set }) => {
-        const name = body.name.trim();
-        const email = body.email.trim();
-        const password = body.password;
+): Elysia => {
+  const app = new Elysia();
 
-        if (!name || !email || !password.trim()) {
-          set.status = 400;
-          return { error: "Invalid request payload" };
+  app.post(
+    "/users",
+    async ({ body, set }) => {
+      const name = body.name.trim();
+      const email = body.email.trim();
+      const password = body.password;
+
+      if (!name || !email || !password.trim()) {
+        set.status = 400;
+        return { error: "Invalid request payload" };
+      }
+
+      try {
+        await (deps.registerUser ?? registerUser)({
+          name,
+          email,
+          password,
+        });
+
+        set.status = 201;
+        return { data: "OK" };
+      } catch (error) {
+        if (error instanceof EmailAlreadyRegisteredError) {
+          set.status = 409;
+          return { error: error.message };
         }
 
-        try {
-          await (deps.registerUser ?? registerUser)({
-            name,
-            email,
-            password,
-          });
+        throw error;
+      }
+    },
+    {
+      body: registerUserBodySchema,
+    },
+  );
 
-          set.status = 201;
-          return { data: "OK" };
-        } catch (error) {
-          if (error instanceof EmailAlreadyRegisteredError) {
-            set.status = 409;
-            return { error: error.message };
-          }
+  app.post(
+    "/users/login",
+    async ({ body, set }) => {
+      const name = body.name.trim();
+      const email = body.email.trim();
+      const password = body.password.trim();
 
-          throw error;
+      if (!name || !email || !password) {
+        set.status = 400;
+        return { error: "Invalid request payload" };
+      }
+
+      try {
+        const token = await (deps.loginUser ?? loginUser)({
+          name,
+          email,
+          password,
+        });
+
+        set.status = 200;
+        return { data: token };
+      } catch (error) {
+        if (error instanceof InvalidLoginError) {
+          set.status = 401;
+          return { error: error.message };
         }
-      },
-      {
-        body: registerUserBodySchema,
-      },
-    )
-    .post(
-      "/users/login",
-      async ({ body, set }) => {
-        const name = body.name.trim();
-        const email = body.email.trim();
-        const password = body.password.trim();
 
-        if (!name || !email || !password) {
-          set.status = 400;
-          return { error: "Invalid request payload" };
-        }
+        throw error;
+      }
+    },
+    {
+      body: loginUserBodySchema,
+    },
+  );
 
-        try {
-          const token = await (deps.loginUser ?? loginUser)({
-            name,
-            email,
-            password,
-          });
+  app.get("/users/current", async ({ headers, set }) => {
+    const token = parseBearerToken(headers.authorization);
 
-          set.status = 200;
-          return { data: token };
-        } catch (error) {
-          if (error instanceof InvalidLoginError) {
-            set.status = 401;
-            return { error: error.message };
-          }
+    if (!token) {
+      set.status = 401;
+      return { error: "Unauthorized" };
+    }
 
-          throw error;
-        }
-      },
-      {
-        body: loginUserBodySchema,
-      },
-    );
+    try {
+      const user = await (deps.getCurrentUserByToken ?? getCurrentUserByToken)(token);
+
+      set.status = 200;
+      return {
+        data: {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          created_at: user.createdAt,
+        },
+      };
+    } catch (error) {
+      if (error instanceof UnauthorizedError) {
+        set.status = 401;
+        return { error: error.message };
+      }
+
+      throw error;
+    }
+  });
+
+  return app;
+};

--- a/src/services/users-service.ts
+++ b/src/services/users-service.ts
@@ -18,6 +18,15 @@ export type LoginUserInput = {
 
 export type LoginUserFn = (input: LoginUserInput) => Promise<string>;
 
+export type CurrentUser = {
+  id: number;
+  name: string;
+  email: string;
+  createdAt: Date | string;
+};
+
+export type GetCurrentUserFn = (token: string) => Promise<CurrentUser>;
+
 export class EmailAlreadyRegisteredError extends Error {
   constructor() {
     super("Email sudah terdaftar");
@@ -29,6 +38,13 @@ export class InvalidLoginError extends Error {
   constructor() {
     super("Email atau password Salah");
     this.name = "InvalidLoginError";
+  }
+}
+
+export class UnauthorizedError extends Error {
+  constructor() {
+    super("Unauthorized");
+    this.name = "UnauthorizedError";
   }
 }
 
@@ -102,4 +118,30 @@ export const loginUser: LoginUserFn = async (input) => {
   });
 
   return token;
+};
+
+export const getCurrentUserByToken: GetCurrentUserFn = async (token) => {
+  const normalizedToken = token.trim();
+
+  if (!normalizedToken) {
+    throw new UnauthorizedError();
+  }
+
+  const userBySession = await db
+    .select({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+      createdAt: users.createdAt,
+    })
+    .from(sessions)
+    .innerJoin(users, eq(sessions.userId, users.id))
+    .where(eq(sessions.token, normalizedToken))
+    .limit(1);
+
+  if (userBySession.length === 0) {
+    throw new UnauthorizedError();
+  }
+
+  return userBySession[0];
 };

--- a/tests/users.test.ts
+++ b/tests/users.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it, mock } from "bun:test";
 import { createApp } from "../src/app";
 import {
   EmailAlreadyRegisteredError,
+  type GetCurrentUserFn,
   InvalidLoginError,
   type LoginUserFn,
   type LoginUserInput,
   type RegisterUserFn,
   type RegisterUserInput,
+  UnauthorizedError,
 } from "../src/services/users-service";
 
 const requestToRegister = (payload: unknown): Request =>
@@ -21,6 +23,12 @@ const requestToLogin = (payload: unknown): Request =>
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(payload),
+  });
+
+const requestToCurrentUser = (authorization?: string): Request =>
+  new Request("http://localhost/api/users/current", {
+    method: "GET",
+    headers: authorization ? { authorization } : undefined,
   });
 
 describe("users registration", () => {
@@ -139,5 +147,69 @@ describe("users login", () => {
     );
 
     expect(response.status).toBe(400);
+  });
+});
+
+describe("current user", () => {
+  it("returns current user for valid bearer token", async () => {
+    let capturedToken: string | null = null;
+
+    const getCurrentUserByTokenMock: GetCurrentUserFn = mock(async (token) => {
+      capturedToken = token;
+      return {
+        id: 1,
+        name: "zaedan",
+        email: "zaedan@gmail.com",
+        createdAt: "2026-04-26T12:34:56.000Z",
+      };
+    });
+
+    const app = createApp({ getCurrentUserByToken: getCurrentUserByTokenMock });
+    const response = await app.handle(requestToCurrentUser("Bearer test-token"));
+
+    expect(response.status).toBe(200);
+    expect(capturedToken).toBe("test-token");
+    expect(await response.json()).toEqual({
+      data: {
+        id: 1,
+        name: "zaedan",
+        email: "zaedan@gmail.com",
+        created_at: "2026-04-26T12:34:56.000Z",
+      },
+    });
+  });
+
+  it("returns unauthorized when authorization header is missing", async () => {
+    const getCurrentUserByTokenMock: GetCurrentUserFn = mock(async () => {
+      throw new Error("must not be called");
+    });
+    const app = createApp({ getCurrentUserByToken: getCurrentUserByTokenMock });
+    const response = await app.handle(requestToCurrentUser());
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns unauthorized for non-bearer authorization header", async () => {
+    const getCurrentUserByTokenMock: GetCurrentUserFn = mock(async () => {
+      throw new Error("must not be called");
+    });
+    const app = createApp({ getCurrentUserByToken: getCurrentUserByTokenMock });
+    const response = await app.handle(requestToCurrentUser("Basic abc123"));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns unauthorized for invalid token", async () => {
+    const getCurrentUserByTokenMock: GetCurrentUserFn = mock(async () => {
+      throw new UnauthorizedError();
+    });
+
+    const app = createApp({ getCurrentUserByToken: getCurrentUserByTokenMock });
+    const response = await app.handle(requestToCurrentUser("Bearer invalid-token"));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
   });
 });


### PR DESCRIPTION
## What Changed
- Added session-based current user lookup in `users-service` via `getCurrentUserByToken(token)`.
- Added `UnauthorizedError` for auth failures.
- Added `GET /api/users/current` route in `users-routes`.
- Implemented bearer token parsing from `Authorization: Bearer <token>`.
- Returned response shape required by issue (`created_at` field in response body).
- Wired dependency injection for `getCurrentUserByToken` in app bootstrap.
- Added tests for current-user endpoint success and unauthorized cases.

## Why
Implements GitHub issue #8 to support retrieving the currently logged-in user from session token authentication.

## Impact
- New API endpoint available: `GET /api/users/current`.
- Auth failures now consistently return `401` with `{ "error": "Unauthorized" }` on this endpoint.
- Existing register/login behavior remains in place.

## Validation
- `bun test tests/health.test.ts tests/users.test.ts` passed (`11 pass`, `0 fail`).