### PR TITLE
[codex] Implement user logout

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,8 @@ import {
   getCurrentUserByToken,
   type GetCurrentUserFn,
   loginUser,
+  logoutUserByToken,
+  type LogoutUserFn,
   registerUser,
   type LoginUserFn,
   type RegisterUserFn,
@@ -15,6 +17,7 @@ type CreateAppDeps = {
   registerUser?: RegisterUserFn;
   loginUser?: LoginUserFn;
   getCurrentUserByToken?: GetCurrentUserFn;
+  logoutUserByToken?: LogoutUserFn;
 };
 
 export const createApp = (deps: CreateAppDeps = {}): Elysia =>
@@ -40,5 +43,6 @@ export const createApp = (deps: CreateAppDeps = {}): Elysia =>
         registerUser: deps.registerUser ?? registerUser,
         loginUser: deps.loginUser ?? loginUser,
         getCurrentUserByToken: deps.getCurrentUserByToken ?? getCurrentUserByToken,
+        logoutUserByToken: deps.logoutUserByToken ?? logoutUserByToken,
       }),
     );

--- a/src/routes/users-routes.ts
+++ b/src/routes/users-routes.ts
@@ -5,6 +5,8 @@ import {
   type GetCurrentUserFn,
   InvalidLoginError,
   loginUser,
+  logoutUserByToken,
+  type LogoutUserFn,
   type LoginUserFn,
   registerUser,
   type RegisterUserFn,
@@ -38,6 +40,7 @@ export const createUsersRoutes = (
     registerUser?: RegisterUserFn;
     loginUser?: LoginUserFn;
     getCurrentUserByToken?: GetCurrentUserFn;
+    logoutUserByToken?: LogoutUserFn;
   } = {},
 ): Elysia => {
   const app = new Elysia();
@@ -132,6 +135,29 @@ export const createUsersRoutes = (
           created_at: user.createdAt,
         },
       };
+    } catch (error) {
+      if (error instanceof UnauthorizedError) {
+        set.status = 401;
+        return { error: error.message };
+      }
+
+      throw error;
+    }
+  });
+
+  app.delete("/users/logout", async ({ headers, set }) => {
+    const token = parseBearerToken(headers.authorization);
+
+    if (!token) {
+      set.status = 401;
+      return { error: "Unauthorized" };
+    }
+
+    try {
+      await (deps.logoutUserByToken ?? logoutUserByToken)(token);
+
+      set.status = 200;
+      return { data: "OK" };
     } catch (error) {
       if (error instanceof UnauthorizedError) {
         set.status = 401;

--- a/src/services/users-service.ts
+++ b/src/services/users-service.ts
@@ -27,6 +27,8 @@ export type CurrentUser = {
 
 export type GetCurrentUserFn = (token: string) => Promise<CurrentUser>;
 
+export type LogoutUserFn = (token: string) => Promise<void>;
+
 export class EmailAlreadyRegisteredError extends Error {
   constructor() {
     super("Email sudah terdaftar");
@@ -144,4 +146,24 @@ export const getCurrentUserByToken: GetCurrentUserFn = async (token) => {
   }
 
   return userBySession[0];
+};
+
+export const logoutUserByToken: LogoutUserFn = async (token) => {
+  const normalizedToken = token.trim();
+
+  if (!normalizedToken) {
+    throw new UnauthorizedError();
+  }
+
+  const existingSession = await db
+    .select({ id: sessions.id })
+    .from(sessions)
+    .where(eq(sessions.token, normalizedToken))
+    .limit(1);
+
+  if (existingSession.length === 0) {
+    throw new UnauthorizedError();
+  }
+
+  await db.delete(sessions).where(eq(sessions.token, normalizedToken));
 };

--- a/tests/users.test.ts
+++ b/tests/users.test.ts
@@ -6,6 +6,7 @@ import {
   InvalidLoginError,
   type LoginUserFn,
   type LoginUserInput,
+  type LogoutUserFn,
   type RegisterUserFn,
   type RegisterUserInput,
   UnauthorizedError,
@@ -28,6 +29,12 @@ const requestToLogin = (payload: unknown): Request =>
 const requestToCurrentUser = (authorization?: string): Request =>
   new Request("http://localhost/api/users/current", {
     method: "GET",
+    headers: authorization ? { authorization } : undefined,
+  });
+
+const requestToLogout = (authorization?: string): Request =>
+  new Request("http://localhost/api/users/logout", {
+    method: "DELETE",
     headers: authorization ? { authorization } : undefined,
   });
 
@@ -208,6 +215,59 @@ describe("current user", () => {
 
     const app = createApp({ getCurrentUserByToken: getCurrentUserByTokenMock });
     const response = await app.handle(requestToCurrentUser("Bearer invalid-token"));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
+  });
+});
+
+describe("users logout", () => {
+  it("logs out user for valid bearer token", async () => {
+    let capturedToken: string | null = null;
+
+    const logoutUserByTokenMock: LogoutUserFn = mock(async (token) => {
+      capturedToken = token;
+    });
+
+    const app = createApp({ logoutUserByToken: logoutUserByTokenMock });
+    const response = await app.handle(requestToLogout("Bearer test-token"));
+
+    expect(response.status).toBe(200);
+    expect(capturedToken).toBe("test-token");
+    expect(await response.json()).toEqual({ data: "OK" });
+  });
+
+  it("returns unauthorized when logout authorization header is missing", async () => {
+    const logoutUserByTokenMock: LogoutUserFn = mock(async () => {
+      throw new Error("must not be called");
+    });
+
+    const app = createApp({ logoutUserByToken: logoutUserByTokenMock });
+    const response = await app.handle(requestToLogout());
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns unauthorized for non-bearer logout authorization header", async () => {
+    const logoutUserByTokenMock: LogoutUserFn = mock(async () => {
+      throw new Error("must not be called");
+    });
+
+    const app = createApp({ logoutUserByToken: logoutUserByTokenMock });
+    const response = await app.handle(requestToLogout("Basic abc123"));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns unauthorized for invalid logout token", async () => {
+    const logoutUserByTokenMock: LogoutUserFn = mock(async () => {
+      throw new UnauthorizedError();
+    });
+
+    const app = createApp({ logoutUserByToken: logoutUserByTokenMock });
+    const response = await app.handle(requestToLogout("Bearer invalid-token"));
 
     expect(response.status).toBe(401);
     expect(await response.json()).toEqual({ error: "Unauthorized" });


### PR DESCRIPTION
## Summary
- Add `logoutUserByToken` service to validate and delete session rows by bearer token.
- Add `DELETE /api/users/logout` route with `Unauthorized` handling for missing, malformed, or invalid tokens.
- Wire logout dependency injection through `createApp` and cover logout behavior in route tests.

## Validation
- `bun test` passed: 15 tests, 0 failures.

Closes #10.
