### PR TITLE
[codex] Add Swagger API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Project ini dibangun dengan Bun, Elysia, Drizzle ORM, dan MySQL. Struktur kode d
 ## Library Utama
 
 - `elysia`: framework HTTP untuk membuat API.
+- `@elysiajs/swagger`: plugin untuk membuat halaman Swagger UI dan OpenAPI JSON.
 - `drizzle-orm`: ORM untuk query database secara typed.
 - `mysql2`: driver koneksi MySQL.
 - `drizzle-kit`: generate dan apply migration dari schema Drizzle.
@@ -133,6 +134,22 @@ Index dan relation:
 ## API yang Tersedia
 
 Semua endpoint berada di bawah prefix dari `API_PREFIX`, default-nya `/api`.
+
+## Swagger Documentation
+
+Setelah server berjalan, Swagger UI tersedia di:
+
+```text
+http://localhost:3000/api/swagger
+```
+
+OpenAPI JSON tersedia di:
+
+```text
+http://localhost:3000/api/swagger/json
+```
+
+Gunakan token dari endpoint `POST /api/users/login` untuk mencoba endpoint yang membutuhkan bearer auth seperti `GET /api/users/current` dan `DELETE /api/users/logout`.
 
 ### `GET /api/`
 
@@ -353,6 +370,7 @@ Test yang tersedia:
 
 - `tests/health.test.ts`: test endpoint health.
 - `tests/root.test.ts`: test root endpoint di bawah API prefix.
+- `tests/swagger.test.ts`: test halaman Swagger UI dan OpenAPI JSON.
 - `tests/users.test.ts`: test registrasi, duplicate email, login, current user, logout, dan integration flow.
 
 ## Scripts

--- a/README.md
+++ b/README.md
@@ -1,56 +1,398 @@
-# Bun + Elysia + Drizzle Template
+# Bun Elysia Drizzle API
 
-Template backend dasar berbasis Bun, Elysia, Drizzle ORM, dan MySQL.
-Project ini sengaja tidak terikat use case/domain tertentu supaya fleksibel dipakai ulang.
+Backend REST API sederhana untuk autentikasi user. Aplikasi ini menyediakan endpoint untuk cek health service, informasi service, registrasi user, login, membaca user yang sedang aktif melalui bearer token, dan logout.
 
-## Prerequisites
+Project ini dibangun dengan Bun, Elysia, Drizzle ORM, dan MySQL. Struktur kode dibuat modular agar route, service, konfigurasi, helper response, dan database schema mudah dikembangkan.
 
-- Bun `>=1.3`
-- Docker + Docker Compose
+## Technology Stack
 
-## Setup Lokal
+- **Runtime**: Bun
+- **Language**: TypeScript
+- **HTTP framework**: Elysia
+- **ORM**: Drizzle ORM
+- **Database**: MySQL 8
+- **Database driver**: mysql2
+- **Migration tool**: drizzle-kit
+- **Testing**: Bun test
+- **Local services**: Docker Compose
+- **Database UI**: phpMyAdmin
 
-1. Install dependency:
+## Library Utama
+
+- `elysia`: framework HTTP untuk membuat API.
+- `drizzle-orm`: ORM untuk query database secara typed.
+- `mysql2`: driver koneksi MySQL.
+- `drizzle-kit`: generate dan apply migration dari schema Drizzle.
+- `typescript`: type system untuk project.
+- `@types/bun`: type definition untuk Bun.
+
+## Struktur Project
+
+```text
+.
+├── drizzle/
+│   ├── 0000_steep_scarlet_witch.sql
+│   ├── 0001_familiar_imperial_guard.sql
+│   └── meta/
+├── src/
+│   ├── app.ts
+│   ├── index.ts
+│   ├── db/
+│   │   ├── client.ts
+│   │   └── schema.ts
+│   ├── lib/
+│   │   ├── config.ts
+│   │   └── response.ts
+│   ├── routes/
+│   │   └── users-routes.ts
+│   └── services/
+│       └── users-service.ts
+├── tests/
+│   ├── health.test.ts
+│   ├── root.test.ts
+│   └── users.test.ts
+├── docker-compose.yml
+├── drizzle.config.ts
+├── package.json
+└── tsconfig.json
+```
+
+## Arsitektur dan Penamaan File
+
+- `src/index.ts`: entry point aplikasi. File ini membuat instance app dan menjalankan server berdasarkan konfigurasi.
+- `src/app.ts`: factory utama Elysia app. Di sini API prefix, global error handler, root endpoint, health endpoint, dan route module digabungkan.
+- `src/routes/*-routes.ts`: layer HTTP route. File route bertanggung jawab membaca request, validasi payload dengan Elysia schema, parsing header, menentukan status code, dan memanggil service.
+- `src/services/*-service.ts`: layer business logic. File service berisi operasi domain seperti register, login, validasi token session, dan logout.
+- `src/db/client.ts`: konfigurasi koneksi MySQL pool dan instance Drizzle.
+- `src/db/schema.ts`: definisi table database Drizzle.
+- `src/lib/config.ts`: pembacaan environment variable dan default config aplikasi.
+- `src/lib/response.ts`: helper response envelope untuk format sukses dan error.
+- `tests/*.test.ts`: test endpoint dan flow API memakai `bun:test`.
+- `drizzle/*.sql`: migration SQL yang dihasilkan oleh drizzle-kit.
+
+Konvensi penamaan yang dipakai:
+
+- Route module memakai suffix `-routes.ts`, contoh `users-routes.ts`.
+- Service module memakai suffix `-service.ts`, contoh `users-service.ts`.
+- Test file memakai suffix `.test.ts`, contoh `users.test.ts`.
+- Database schema diletakkan terpusat di `src/db/schema.ts`.
+
+## Environment Variable
+
+Contoh konfigurasi tersedia di `.env.example`.
+
+```env
+APP_PORT=3000
+API_PREFIX=/api
+
+MYSQL_HOST=127.0.0.1
+MYSQL_PORT=3306
+MYSQL_USER=root
+MYSQL_PASSWORD=my-secret-pw
+MYSQL_DATABASE=mydb
+```
+
+Default API base URL lokal:
+
+```text
+http://localhost:3000/api
+```
+
+## Database Schema
+
+Schema utama didefinisikan di `src/db/schema.ts` dan migration SQL berada di folder `drizzle/`.
+
+### `users`
+
+| Column | Type | Constraint | Keterangan |
+| --- | --- | --- | --- |
+| `id` | `int` | Primary key, auto increment | ID user |
+| `name` | `varchar(255)` | Not null | Nama user |
+| `email` | `varchar(255)` | Not null, unique | Email user, dinormalisasi menjadi lowercase |
+| `password` | `varchar(255)` | Not null | Password yang sudah di-hash dengan bcrypt |
+| `created_at` | `timestamp` | Not null, default `now()` | Waktu user dibuat |
+
+Index:
+
+- `users_email_unique` pada column `email`.
+
+### `sessions`
+
+| Column | Type | Constraint | Keterangan |
+| --- | --- | --- | --- |
+| `id` | `int` | Primary key, auto increment | ID session |
+| `token` | `varchar(255)` | Not null, unique | Session token dari `crypto.randomUUID()` |
+| `user_id` | `int` | Not null, foreign key ke `users.id` | Pemilik session |
+| `created_at` | `timestamp` | Not null, default `now()` | Waktu session dibuat |
+
+Index dan relation:
+
+- `sessions_token_unique` pada column `token`.
+- `sessions.user_id` reference ke `users.id`.
+
+## API yang Tersedia
+
+Semua endpoint berada di bawah prefix dari `API_PREFIX`, default-nya `/api`.
+
+### `GET /api/`
+
+Mengembalikan informasi service.
+
+Response `200`:
+
+```json
+{
+  "data": {
+    "service": "api-template",
+    "version": "v1"
+  },
+  "error": null,
+  "meta": {}
+}
+```
+
+### `GET /api/health`
+
+Mengecek status service.
+
+Response `200`:
+
+```json
+{
+  "data": {
+    "status": "ok"
+  },
+  "error": null,
+  "meta": {}
+}
+```
+
+### `POST /api/users`
+
+Registrasi user baru.
+
+Request body:
+
+```json
+{
+  "name": "Zaedan",
+  "email": "zaedan@example.com",
+  "password": "rahasia"
+}
+```
+
+Response `201`:
+
+```json
+{
+  "data": "OK"
+}
+```
+
+Kemungkinan error:
+
+- `400`: payload kosong, tidak lengkap, atau tipe data tidak valid.
+- `409`: email sudah terdaftar.
+
+### `POST /api/users/login`
+
+Login user dan membuat session token.
+
+Request body:
+
+```json
+{
+  "name": "Zaedan",
+  "email": "zaedan@example.com",
+  "password": "rahasia"
+}
+```
+
+Response `200`:
+
+```json
+{
+  "data": "session-token"
+}
+```
+
+Kemungkinan error:
+
+- `400`: payload kosong, tidak lengkap, atau tipe data tidak valid.
+- `401`: email atau password salah.
+
+### `GET /api/users/current`
+
+Mengambil data user aktif berdasarkan bearer token.
+
+Header:
+
+```text
+Authorization: Bearer session-token
+```
+
+Response `200`:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "name": "Zaedan",
+    "email": "zaedan@example.com",
+    "created_at": "2026-05-01T03:00:00.000Z"
+  }
+}
+```
+
+Kemungkinan error:
+
+- `401`: token tidak ada, format authorization salah, token kosong, atau session tidak ditemukan.
+
+### `DELETE /api/users/logout`
+
+Logout user dengan menghapus session token.
+
+Header:
+
+```text
+Authorization: Bearer session-token
+```
+
+Response `200`:
+
+```json
+{
+  "data": "OK"
+}
+```
+
+Kemungkinan error:
+
+- `401`: token tidak ada, format authorization salah, token kosong, atau session tidak ditemukan.
+
+## Setup Project
+
+### 1. Install dependency
 
 ```bash
 bun install
 ```
 
-2. Salin env:
+### 2. Salin environment file
 
 ```bash
 cp .env.example .env
 ```
 
-3. Jalankan MySQL:
+Di Windows PowerShell:
+
+```powershell
+Copy-Item .env.example .env
+```
+
+### 3. Jalankan MySQL dan phpMyAdmin
 
 ```bash
 docker compose up -d
 ```
 
-4. Jalankan server:
+Service yang dijalankan:
+
+- MySQL: `localhost:3306`
+- phpMyAdmin: `http://localhost:8080`
+
+### 4. Jalankan migration
+
+```bash
+bun run db:migrate
+```
+
+Jika mengubah `src/db/schema.ts`, generate migration baru terlebih dahulu:
+
+```bash
+bun run db:generate
+```
+
+Lalu apply migration:
+
+```bash
+bun run db:migrate
+```
+
+## Cara Run Aplikasi
+
+Development mode dengan watch:
 
 ```bash
 bun run dev
 ```
 
-Server tersedia di `http://localhost:3000/api/v1`.
+Production-style run lokal:
+
+```bash
+bun run start
+```
+
+Server akan berjalan di:
+
+```text
+http://localhost:3000/api
+```
+
+## Cara Test Aplikasi
+
+Pastikan MySQL sudah berjalan dan migration sudah diterapkan, karena test user memakai database.
+
+```bash
+docker compose up -d
+bun run db:migrate
+bun run test
+```
+
+Test yang tersedia:
+
+- `tests/health.test.ts`: test endpoint health.
+- `tests/root.test.ts`: test root endpoint di bawah API prefix.
+- `tests/users.test.ts`: test registrasi, duplicate email, login, current user, logout, dan integration flow.
 
 ## Scripts
 
-- `bun run dev` menjalankan server dengan watch mode.
-- `bun run start` menjalankan server normal.
-- `bun run test` menjalankan test endpoint dasar.
-- `bun run db:generate` generate migrasi dari schema Drizzle.
-- `bun run db:migrate` apply migrasi ke MySQL.
+| Script | Fungsi |
+| --- | --- |
+| `bun run dev` | Menjalankan server dengan watch mode |
+| `bun run start` | Menjalankan server normal |
+| `bun run test` | Menjalankan test suite |
+| `bun run db:generate` | Generate migration dari schema Drizzle |
+| `bun run db:migrate` | Apply migration ke MySQL |
 
-## Endpoint Template
+## Contoh Request
 
-- `GET /api/v1/health`
+Register:
 
-## Menambahkan Use Case Sendiri
+```bash
+curl -X POST http://localhost:3000/api/users \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Zaedan","email":"zaedan@example.com","password":"rahasia"}'
+```
 
-1. Tambahkan table di `src/db/schema.ts`.
-2. Jalankan `bun run db:generate`.
-3. Jalankan `bun run db:migrate`.
-4. Tambahkan route di `src/routes/` dan mount di `src/app.ts`.
+Login:
+
+```bash
+curl -X POST http://localhost:3000/api/users/login \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Zaedan","email":"zaedan@example.com","password":"rahasia"}'
+```
+
+Current user:
+
+```bash
+curl http://localhost:3000/api/users/current \
+  -H "Authorization: Bearer session-token"
+```
+
+Logout:
+
+```bash
+curl -X DELETE http://localhost:3000/api/users/logout \
+  -H "Authorization: Bearer session-token"
+```

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "belajar-vibe-coding",
       "dependencies": {
+        "@elysiajs/swagger": "^1.3.1",
         "drizzle-orm": "^0.45.2",
         "elysia": "^1.4.28",
         "mysql2": "^3.22.1",
@@ -22,6 +23,8 @@
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
+    "@elysiajs/swagger": ["@elysiajs/swagger@1.3.1", "", { "dependencies": { "@scalar/themes": "^0.9.52", "@scalar/types": "^0.0.12", "openapi-types": "^12.1.3", "pathe": "^1.1.2" }, "peerDependencies": { "elysia": ">= 1.3.0" } }, "sha512-LcbLHa0zE6FJKWPWKsIC/f+62wbDv3aXydqcNPVPyqNcaUgwvCajIi+5kHEU6GO3oXUCpzKaMsb3gsjt8sLzFQ=="],
 
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 
@@ -79,6 +82,12 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
+    "@scalar/openapi-types": ["@scalar/openapi-types@0.1.1", "", {}, "sha512-NMy3QNk6ytcCoPUGJH0t4NNr36OWXgZhA3ormr3TvhX1NDgoF95wFyodGVH8xiHeUyn2/FxtETm8UBLbB5xEmg=="],
+
+    "@scalar/themes": ["@scalar/themes@0.9.86", "", { "dependencies": { "@scalar/types": "0.1.7" } }, "sha512-QUHo9g5oSWi+0Lm1vJY9TaMZRau8LHg+vte7q5BVTBnu6NuQfigCaN+ouQ73FqIVd96TwMO6Db+dilK1B+9row=="],
+
+    "@scalar/types": ["@scalar/types@0.0.12", "", { "dependencies": { "@scalar/openapi-types": "0.1.1", "@unhead/schema": "^1.9.5" } }, "sha512-XYZ36lSEx87i4gDqopQlGCOkdIITHHEvgkuJFrXFATQs9zHARop0PN0g4RZYWj+ZpCUclOcaOjbCt8JGe22mnQ=="],
+
     "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
@@ -88,6 +97,8 @@
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@unhead/schema": ["@unhead/schema@1.11.20", "", { "dependencies": { "hookable": "^5.5.3", "zhead": "^2.2.4" } }, "sha512-0zWykKAaJdm+/Y7yi/Yds20PrUK7XabLe9c3IRcjnwYmSWY6z0Cr19VIs3ozCj8P+GhR+/TI2mwtGlueCEYouA=="],
 
     "aws-ssl-profiles": ["aws-ssl-profiles@1.1.2", "", {}, "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="],
 
@@ -121,6 +132,8 @@
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
+    "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
+
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
@@ -139,7 +152,11 @@
 
     "named-placeholders": ["named-placeholders@1.1.6", "", { "dependencies": { "lru.min": "^1.1.0" } }, "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w=="],
 
+    "nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
+
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
+
+    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
@@ -157,13 +174,21 @@
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
+    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
+    "zhead": ["zhead@2.2.4", "", {}, "sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
+    "@scalar/themes/@scalar/types": ["@scalar/types@0.1.7", "", { "dependencies": { "@scalar/openapi-types": "0.2.0", "@unhead/schema": "^1.11.11", "nanoid": "^5.1.5", "type-fest": "^4.20.0", "zod": "^3.23.8" } }, "sha512-irIDYzTQG2KLvFbuTI8k2Pz/R4JR+zUUSykVTbEMatkzMmVFnn1VzNSMlODbadycwZunbnL2tA27AXed9URVjw=="],
 
     "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
@@ -210,6 +235,8 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "@scalar/themes/@scalar/types/@scalar/openapi-types": ["@scalar/openapi-types@0.2.0", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-waiKk12cRCqyUCWTOX0K1WEVX46+hVUK+zRPzAahDJ7G0TApvbNkuy5wx7aoUyEk++HHde0XuQnshXnt8jsddA=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typescript": "^5"
   },
   "dependencies": {
+    "@elysiajs/swagger": "^1.3.1",
     "drizzle-orm": "^0.45.2",
     "elysia": "^1.4.28",
     "mysql2": "^3.22.1"

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,4 @@
+import { swagger } from "@elysiajs/swagger";
 import { Elysia, t } from "elysia";
 import { config } from "./lib/config";
 import { failure, success } from "./lib/response";
@@ -45,9 +46,41 @@ export const createApp = (deps: CreateAppDeps = {}): Elysia =>
       set.status = 500;
       return failure("INTERNAL_SERVER_ERROR", "Unexpected server error");
     })
-    .get("/health", () => success({ status: "ok" }))
+    .use(
+      swagger({
+        path: "/swagger",
+        provider: "swagger-ui",
+        documentation: {
+          info: {
+            title: "Bun Elysia Drizzle API",
+            version: "1.0.0",
+            description: "REST API sederhana untuk autentikasi user.",
+          },
+          components: {
+            securitySchemes: {
+              bearerAuth: {
+                type: "http",
+                scheme: "bearer",
+                bearerFormat: "UUID",
+              },
+            },
+          },
+        },
+      }),
+    )
+    .get("/health", () => success({ status: "ok" }), {
+      detail: {
+        tags: ["System"],
+        summary: "Health check",
+        description: "Mengecek apakah service API berjalan.",
+      },
+    })
     .get("/", () => success({ service: "api-template", version: "v1" }), {
-      detail: { hide: true },
+      detail: {
+        tags: ["System"],
+        summary: "Service information",
+        description: "Mengembalikan informasi singkat tentang service.",
+      },
       response: t.Any(),
     })
     .use(

--- a/src/routes/users-routes.ts
+++ b/src/routes/users-routes.ts
@@ -14,15 +14,39 @@ import {
 } from "../services/users-service";
 
 const registerUserBodySchema = t.Object({
-  name: t.String({ minLength: 1 }),
-  email: t.String({ minLength: 1 }),
-  password: t.String({ minLength: 1 }),
+  name: t.String({
+    minLength: 1,
+    description: "Nama user.",
+    examples: ["Zaedan"],
+  }),
+  email: t.String({
+    minLength: 1,
+    description: "Email user yang akan dinormalisasi menjadi lowercase.",
+    examples: ["zaedan@example.com"],
+  }),
+  password: t.String({
+    minLength: 1,
+    description: "Password user yang akan disimpan sebagai hash bcrypt.",
+    examples: ["rahasia"],
+  }),
 });
 
 const loginUserBodySchema = t.Object({
-  name: t.String({ minLength: 1 }),
-  email: t.String({ minLength: 1 }),
-  password: t.String({ minLength: 1 }),
+  name: t.String({
+    minLength: 1,
+    description: "Nama user.",
+    examples: ["Zaedan"],
+  }),
+  email: t.String({
+    minLength: 1,
+    description: "Email user.",
+    examples: ["zaedan@example.com"],
+  }),
+  password: t.String({
+    minLength: 1,
+    description: "Password user.",
+    examples: ["rahasia"],
+  }),
 });
 
 const parseBearerToken = (authorization?: string): string | null => {
@@ -77,6 +101,22 @@ export const createUsersRoutes = (
     },
     {
       body: registerUserBodySchema,
+      detail: {
+        tags: ["Users"],
+        summary: "Register user",
+        description: "Membuat user baru dengan email unik dan password bcrypt.",
+        responses: {
+          201: {
+            description: "User berhasil dibuat.",
+          },
+          400: {
+            description: "Payload kosong, tidak lengkap, atau tidak valid.",
+          },
+          409: {
+            description: "Email sudah terdaftar.",
+          },
+        },
+      },
     },
   );
 
@@ -112,61 +152,117 @@ export const createUsersRoutes = (
     },
     {
       body: loginUserBodySchema,
+      detail: {
+        tags: ["Users"],
+        summary: "Login user",
+        description: "Memvalidasi credential user dan membuat session token.",
+        responses: {
+          200: {
+            description: "Login berhasil dan token session dikembalikan.",
+          },
+          400: {
+            description: "Payload kosong, tidak lengkap, atau tidak valid.",
+          },
+          401: {
+            description: "Email atau password salah.",
+          },
+        },
+      },
     },
   );
 
-  app.get("/users/current", async ({ headers, set }) => {
-    const token = parseBearerToken(headers.authorization);
+  app.get(
+    "/users/current",
+    async ({ headers, set }) => {
+      const token = parseBearerToken(headers.authorization);
 
-    if (!token) {
-      set.status = 401;
-      return { error: "Unauthorized" };
-    }
+      if (!token) {
+        set.status = 401;
+        return { error: "Unauthorized" };
+      }
 
-    try {
-      const user = await (deps.getCurrentUserByToken ?? getCurrentUserByToken)(token);
+      try {
+        const user = await (deps.getCurrentUserByToken ?? getCurrentUserByToken)(
+          token,
+        );
 
-      set.status = 200;
-      return {
-        data: {
-          id: user.id,
-          name: user.name,
-          email: user.email,
-          created_at: user.createdAt,
+        set.status = 200;
+        return {
+          data: {
+            id: user.id,
+            name: user.name,
+            email: user.email,
+            created_at: user.createdAt,
+          },
+        };
+      } catch (error) {
+        if (error instanceof UnauthorizedError) {
+          set.status = 401;
+          return { error: error.message };
+        }
+
+        throw error;
+      }
+    },
+    {
+      detail: {
+        tags: ["Users"],
+        summary: "Get current user",
+        description: "Mengambil data user aktif berdasarkan bearer token.",
+        security: [{ bearerAuth: [] }],
+        responses: {
+          200: {
+            description: "Data user aktif berhasil dikembalikan.",
+          },
+          401: {
+            description: "Bearer token tidak ada, tidak valid, atau session tidak ditemukan.",
+          },
         },
-      };
-    } catch (error) {
-      if (error instanceof UnauthorizedError) {
+      },
+    },
+  );
+
+  app.delete(
+    "/users/logout",
+    async ({ headers, set }) => {
+      const token = parseBearerToken(headers.authorization);
+
+      if (!token) {
         set.status = 401;
-        return { error: error.message };
+        return { error: "Unauthorized" };
       }
 
-      throw error;
-    }
-  });
+      try {
+        await (deps.logoutUserByToken ?? logoutUserByToken)(token);
 
-  app.delete("/users/logout", async ({ headers, set }) => {
-    const token = parseBearerToken(headers.authorization);
+        set.status = 200;
+        return { data: "OK" };
+      } catch (error) {
+        if (error instanceof UnauthorizedError) {
+          set.status = 401;
+          return { error: error.message };
+        }
 
-    if (!token) {
-      set.status = 401;
-      return { error: "Unauthorized" };
-    }
-
-    try {
-      await (deps.logoutUserByToken ?? logoutUserByToken)(token);
-
-      set.status = 200;
-      return { data: "OK" };
-    } catch (error) {
-      if (error instanceof UnauthorizedError) {
-        set.status = 401;
-        return { error: error.message };
+        throw error;
       }
-
-      throw error;
-    }
-  });
+    },
+    {
+      detail: {
+        tags: ["Users"],
+        summary: "Logout user",
+        description: "Menghapus session berdasarkan bearer token.",
+        security: [{ bearerAuth: [] }],
+        responses: {
+          200: {
+            description: "Logout berhasil dan session dihapus.",
+          },
+          401: {
+            description: "Bearer token tidak ada, tidak valid, atau session tidak ditemukan.",
+          },
+        },
+      },
+    },
+  );
 
   return app;
 };

--- a/src/services/users-service.ts
+++ b/src/services/users-service.ts
@@ -29,6 +29,7 @@ export type GetCurrentUserFn = (token: string) => Promise<CurrentUser>;
 
 export type LogoutUserFn = (token: string) => Promise<void>;
 
+/** Error khusus saat email yang dipakai register sudah ada di database. */
 export class EmailAlreadyRegisteredError extends Error {
   constructor() {
     super("Email sudah terdaftar");
@@ -36,6 +37,7 @@ export class EmailAlreadyRegisteredError extends Error {
   }
 }
 
+/** Error khusus saat kombinasi email dan password tidak valid. */
 export class InvalidLoginError extends Error {
   constructor() {
     super("Email atau password Salah");
@@ -43,6 +45,7 @@ export class InvalidLoginError extends Error {
   }
 }
 
+/** Error khusus saat token session tidak valid atau tidak ditemukan. */
 export class UnauthorizedError extends Error {
   constructor() {
     super("Unauthorized");
@@ -50,8 +53,10 @@ export class UnauthorizedError extends Error {
   }
 }
 
+/** Merapikan email agar comparison dan penyimpanan selalu konsisten. */
 const normalizeEmail = (email: string): string => email.trim().toLowerCase();
 
+/** Mengecek apakah error database berasal dari pelanggaran unique constraint. */
 const isDuplicateKeyError = (error: unknown): boolean => {
   if (!error || typeof error !== "object") return false;
 
@@ -59,6 +64,7 @@ const isDuplicateKeyError = (error: unknown): boolean => {
   return maybeError.code === "ER_DUP_ENTRY" || maybeError.errno === 1062;
 };
 
+/** Membuat user baru, melakukan hash password, dan menolak email duplikat. */
 export const registerUser: RegisterUserFn = async (input) => {
   const email = normalizeEmail(input.email);
 
@@ -92,6 +98,7 @@ export const registerUser: RegisterUserFn = async (input) => {
   }
 };
 
+/** Memvalidasi credential user, membuat session baru, lalu mengembalikan token. */
 export const loginUser: LoginUserFn = async (input) => {
   const email = normalizeEmail(input.email);
 
@@ -122,6 +129,7 @@ export const loginUser: LoginUserFn = async (input) => {
   return token;
 };
 
+/** Mengambil data user aktif berdasarkan token session yang dikirim client. */
 export const getCurrentUserByToken: GetCurrentUserFn = async (token) => {
   const normalizedToken = token.trim();
 
@@ -148,6 +156,7 @@ export const getCurrentUserByToken: GetCurrentUserFn = async (token) => {
   return userBySession[0];
 };
 
+/** Menghapus session berdasarkan token agar user dianggap logout. */
 export const logoutUserByToken: LogoutUserFn = async (token) => {
   const normalizedToken = token.trim();
 

--- a/tests/swagger.test.ts
+++ b/tests/swagger.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { createApp } from "../src/app";
+
+describe("swagger documentation", () => {
+  it("exposes swagger ui under api prefix", async () => {
+    const app = createApp();
+    const response = await app.handle(new Request("http://localhost/api/swagger"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/html");
+  });
+
+  it("exposes openapi json with current api paths", async () => {
+    const app = createApp();
+    const response = await app.handle(
+      new Request("http://localhost/api/swagger/json"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.paths["/api/"]).toBeDefined();
+    expect(body.paths["/api/health"]).toBeDefined();
+    expect(body.paths["/api/users"]).toBeDefined();
+    expect(body.paths["/api/users/login"]).toBeDefined();
+    expect(body.paths["/api/users/current"]).toBeDefined();
+    expect(body.paths["/api/users/logout"]).toBeDefined();
+    expect(body.components.securitySchemes.bearerAuth).toMatchObject({
+      type: "http",
+      scheme: "bearer",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `@elysiajs/swagger` and expose Swagger UI at `/api/swagger` with OpenAPI JSON at `/api/swagger/json`.
- Document system and users endpoints with tags, summaries, descriptions, response notes, and bearer auth metadata.
- Add Swagger tests and update README with Swagger usage instructions.

## Validation

- `bun run test` passed: 22 tests, 0 failures.

## Notes

- Implements #14.
- Local `issue.md` remains uncommitted because it was the planning document used to create the GitHub issue, not part of the Swagger implementation.
